### PR TITLE
Update shapeit4 to v4.2.1

### DIFF
--- a/recipes/shapeit4/meta.yaml
+++ b/recipes/shapeit4/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   skip: True  # [osx]
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/shapeit4/meta.yaml
+++ b/recipes/shapeit4/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.2.0" %}
+{% set version = "4.2.1" %}
 
 package:
   name: shapeit4
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/odelaneau/shapeit4/archive/v{{ version }}.tar.gz
-  sha256: 329aa920be49b085c96b420d4f42ade7ba92eae8a202ecb2f71ca32a61955588
+  sha256: 54544dc00c5dc805a8de315c74e14e6d3c382632eee8bc6609c775d1624ccda8
 
 build:
   skip: True  # [osx]


### PR DESCRIPTION
Recommended by developer to resolve `invalid pointer` error when using shapeit4 through conda (see odelaneau/shapeit4#54 (comment))